### PR TITLE
Support Sphinx 2+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ here = os.path.dirname(os.path.abspath(__file__))
 
 
 requires = [
-    'Sphinx>=0.6',
+    'Sphinx>1.6',
 ]
 
 

--- a/sphinxcontrib/autoanysrc.py
+++ b/sphinxcontrib/autoanysrc.py
@@ -6,8 +6,12 @@ import importlib
 
 from sphinx.util.console import bold
 from sphinx.ext.autodoc import Documenter
+from sphinx.util import logging
 
 from . import analyzers
+
+
+logger = logging.getLogger(__name__)
 
 
 class AnySrcDocumenter(Documenter):
@@ -58,7 +62,7 @@ class AnySrcDocumenter(Documenter):
             cls.register_analyzer(key, import_class(value))
 
     def info(self, msg):
-        self.directive.env.app.info('    <autoanysrc> %s' % msg)
+        logger.info('    <autoanysrc> %s' % msg)
 
     def collect_files(self):
         arg = self.options.src

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,16 @@
 [tox]
-envlist=py27,py34,qa
+envlist = py{27,36}-sphinx{1,2,3},qa
 
 [testenv]
 deps=
-    sphinx
     nose
+    sphinx1: Sphinx < 2.0
+    sphinx2: Sphinx < 3.0
+    sphinx3: Sphinx < 4.0
 commands=
     python -V
     python -c "import sphinx; print('Sphinx version: %s' % sphinx.__version__);"
     nosetests tests
-
-[testenv:py27]
-basepython=python2.7
-
-[testenv:py34]
-basepython=python3.4 
 
 [testenv:qa]
 deps=


### PR DESCRIPTION
The logging call API was deprecated back in 1.6 and removed in 2.0. This
updates the logging API usage and expands Tox testing of python/sphinx
versions.